### PR TITLE
Control crawl depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,18 @@ At a minimum, you will need `Scrapy` and `BeautifulSoup` for the baseline functi
 
 To start the crawling process, you will need to pass a url to the MediaSpider via the Scrapy CLI.
 
-First, `cd` into `media-crawler/crawler`, (where the `scrapy.cfg` file is). Then, run this command, passing the spider the URL you want to start with:
+First, `cd` into `media-crawler/crawler`, (where the `scrapy.cfg` file is). Then, run this command, passing the spider the URL you want to start with.
+
+In addition to the `media_url` argument, you may pass in a `max_depth` argument specifying how many references deep you want the tree to be constructed. The default is `3`.
+
+Do not forget to output to a JSON data file at the end of the command via `-o media.json`. It is hard to see in the example below without scrolling, as that is not a small URL.
 
 ```bash
-scrapy crawl media_spider -a media_url="https://www.washingtonpost.com/news/post-politics/wp/2017/09/07/did-facebook-ads-traced-to-a-russian-company-violate-u-s-election-law/?tid=a_inl&utm_term=.e24142917aa8" -o media.json
+scrapy crawl media_spider -a media_url="https://www.washingtonpost.com/news/post-politics/wp/2017/09/07/did-facebook-ads-traced-to-a-russian-company-violate-u-s-election-law/?tid=a_inl&utm_term=.e24142917aa8" max_depth=5 -o media.json
 ```
 
-Here, we use a Washington Post article as an example. Feel free to use this as a baseline test.
+Here, we use a Washington Post article as an example and go five references deep with it as the starting point. Feel free to use this as a baseline test.
 
-**Note: At the moment, we do not control the depth to which the spider scrapes. Once you have scraped enough to determine the performance of the crawler, hit `CTRL-C` once (multiple times won't allow the spider to soft stop) to make the crawl stop. You can see the results in `media-crawler/crawler/media.json`, as this is the file specified in the command above.**
 
 ## Contributing
 

--- a/crawler/crawler/spiders/media_spider.py
+++ b/crawler/crawler/spiders/media_spider.py
@@ -17,13 +17,13 @@ class MediaSpider(scrapy.Spider):
     name = 'media_spider'
     parent_node_lookup = {}
 
-    def __init__(self, media_url='', max_depth=3, *args, **kwargs):
+    def __init__(self, media_url='', max_depth='3', *args, **kwargs):
         super(MediaSpider, self).__init__(*args, **kwargs)
         assert media_url, '''
         media_spider was not initialized with starting media_url
         '''
         self._media_url = media_url
-        self._max_depth = max_depth
+        self._max_depth = int(max_depth)
 
     def start_requests(self):
         """Start crawl wih given media url

--- a/crawler/crawler/spiders/media_spider.py
+++ b/crawler/crawler/spiders/media_spider.py
@@ -12,15 +12,18 @@ class MediaSpider(scrapy.Spider):
 
     Args:
         media_url (str): url to parse as root
+        max_depth (int): maximum depth to go to in depth-first crawl
     """
     name = 'media_spider'
+    parent_node_lookup = {}
 
-    def __init__(self, media_url='', *args, **kwargs):
+    def __init__(self, media_url='', max_depth=3, *args, **kwargs):
         super(MediaSpider, self).__init__(*args, **kwargs)
         assert media_url, '''
         media_spider was not initialized with starting media_url
         '''
         self._media_url = media_url
+        self._max_depth = max_depth
 
     def start_requests(self):
         """Start crawl wih given media url
@@ -28,22 +31,47 @@ class MediaSpider(scrapy.Spider):
         # Yield a request which will be picked up by the spider
         yield scrapy.Request(self._media_url, self.parse_media_references)
 
+    def get_node_depth(self, node_url):
+        """Given the URL of a media node, track its depth in the current crawl
+        """
+        depth = 0
+        parent_node = node_url # At depth zero, start with current node
+        while parent_node is not None:
+            # Inclusive of the first node given, count every parent traversed
+            depth += 1
+            # use .get() to default to None if a parent node can't be found
+            parent_node = self.parent_node_lookup.get(parent_node, None)
+        return depth
+
     def parse_media_references(self, response):
         """Given a response to a scrapy.Request, parse out and delegate all media references
+
+        This performs a depth-first tree traversal across the references in the given
+        media. The depth of the traversal (and therefore the tree) is determined by the
+        max_depth argument passed into the spider on initialization (defaults to max_depth=3)
         """
         # Try to retrieve a parser for the given url
         parser = get_parser(response.url)
         # Clean up the url to use as an identifier
         clean_url = response.url.split('?')[0]
+        # Get the depth of the crawl thus far
+        crawl_depth = self.get_node_depth(clean_url)
 
         # If there was a valid parser found...
         if parser:
             # Parse out the references
             references = parser(response)
 
-            # For every reference, delegate a request for it to be scraped as well
-            for ref in references:
-                yield scrapy.Request(ref['href'], self.parse_media_references)
+            # If the max depth hasn't been reached, continue the crawl
+            if crawl_depth < self._max_depth:
+                # For every reference, delegate a request for it to be scraped as well
+                for ref in references:
+                    # Clean kwargs from ref url
+                    clean_ref_url = ref['href'].split('?')[0]
+                    # Track parent nodes to determine depth
+                    self.parent_node_lookup[clean_ref_url] = clean_url
+                    # Yield a request for Scrapy to process
+                    yield scrapy.Request(ref['href'], self.parse_media_references)
 
             # After processing all references, yield the root media item given.
             # Note: this is recursive, technically, so this is the root of the

--- a/crawler/crawler/spiders/media_spider.py
+++ b/crawler/crawler/spiders/media_spider.py
@@ -63,7 +63,7 @@ class MediaSpider(scrapy.Spider):
             references = parser(response)
 
             # If the max depth hasn't been reached, continue the crawl
-            if crawl_depth < self._max_depth:
+            if crawl_depth <= self._max_depth:
                 # For every reference, delegate a request for it to be scraped as well
                 for ref in references:
                     # Clean kwargs from ref url


### PR DESCRIPTION
This tracks the parent node of a crawled url through a dictionary within the spider instance.
Then, given any url, we can track how deep the request is via recursion.