### PR TITLE
added fox news parser to solve issue #13

### DIFF
--- a/crawler/crawler/parsers/fox_news.py
+++ b/crawler/crawler/parsers/fox_news.py
@@ -1,0 +1,50 @@
+from bs4 import BeautifulSoup
+from unicodedata import normalize
+
+
+def parse_fox_news_references(response):
+    """Given a typical article on Fox News, parse out reference links
+    Args:
+        response: scrapy response object
+    Returns:
+        list(dict) of references and their respective contexts
+    """
+    # Create list to store references
+    references = []
+
+    # Get all <p> tags in the article body
+    article_p_tags = response.xpath("//div[@class='article-body']")[0].css('p')
+
+    # Preserve all tags which have links within their children
+    linking_p_tags = [tag for tag in article_p_tags if len(tag.css('a'))]
+
+    # For every tag, create a reference for every link therein
+    for tag in linking_p_tags:
+        # Use BeautifulSoup + unicodedate.normalize to get a clean context
+        # to use in establishing the context of each link reference
+        context_soup = BeautifulSoup(tag.get())
+
+        # A lot of times we will get some weird \xa0 (special whitespace) characters
+        # in the mix. We do not want these in our results. For information on this, see:
+        # https://docs.python.org/2/library/unicodedata.html#unicodedata.normalize
+        cleaned_context = normalize('NFKD', context_soup.get_text())
+
+        # Grab every link within with a css selector
+        for link in tag.css('a'):
+            # Get the href from inside the anchor (link) tag
+            link_href = link.xpath('@href').extract()[0]
+
+            # Get the inner text of the link to use as a reference
+            # with respect to the context
+            link_text = link.xpath('text()').extract()[0]
+
+            # Use what we retrieved to create a dict object containing the data
+            reference = {
+                'href': link_href,
+                'text': link_text,
+                'context': cleaned_context
+            }
+            references.append(reference)
+    # Return our created list
+    return references
+

--- a/crawler/crawler/parsers/parser.py
+++ b/crawler/crawler/parsers/parser.py
@@ -2,7 +2,7 @@ import re
 
 # Import parsers
 from crawler.parsers.washington_post import parse_washington_post_references
-
+from crawler.parsers.fox_news import parse_fox_news_references
 
 # As article links can be a bit nebulous, we want to specify a regex
 # pattern to match against each given url to determine the most
@@ -12,7 +12,8 @@ from crawler.parsers.washington_post import parse_washington_post_references
 #   If you don't import your parser and add it to this map,
 #   it will not be picked up for a relevant url by the spider!
 parser_map = {
-    '.+\.washingtonpost\.com.+': parse_washington_post_references
+    '.+\.washingtonpost\.com.+': parse_washington_post_references,
+    '.+\.foxnews\.com+': parse_fox_news_references
 }
 
 


### PR DESCRIPTION
Added a parser for fox news articles following the wapo example. I also added the import statement and updated the parser map dictionary in parser.py. Haven't tested on older articles, but I did test on a few newer ones. I included an example below from http://www.foxnews.com/world/2017/10/01/canada-terror-attack-captured-on-video-at-least-5-wounded.html 

[example_fox_news.txt](https://github.com/Data4Democracy/media-crawler/files/1347569/example_fox_news.txt)
